### PR TITLE
change from cirros to precise for test_file.

### DIFF
--- a/manifests/test_file.pp
+++ b/manifests/test_file.pp
@@ -16,7 +16,7 @@
 class openstack::test_file(
   $path         = '/tmp/test_nova.sh',
   $rc_file_path = '/root/openrc',
-  $image_type   = 'cirros',
+  $image_type   = 'precise',
   $sleep_time   = '15',
   $floating_ip  = true
 ) {


### PR DESCRIPTION
This change addresses an incompatibility with floating_ips and kvm/qemu and Cisco VIC interfaces.
