### PR TITLE
Fix typo in variable name

### DIFF
--- a/manifests/controller.pp
+++ b/manifests/controller.pp
@@ -109,7 +109,7 @@ class openstack::controller(
   $host         = 'controller',
 #guantum general
   $quantum_enabled              = true,
-  $qunatum_package_ensure       = present,
+  $quantum_package_ensure       = present,
   $quantum_log_verbose          = "True",
   $quantum_log_debug            = "True",
   $quantum_bind_host            = "0.0.0.0",


### PR DESCRIPTION
s/qunatum/quantum/
