### PR TITLE
Add OVS provider parameters to all.pp

### DIFF
--- a/manifests/all.pp
+++ b/manifests/all.pp
@@ -45,6 +45,10 @@
 # [cache_server_port]   local memcached instance port
 # [horizon]             (bool) is horizon installed. Defaults to: true
 # [quantum]             (bool) is quantum installed
+# [newtork_vlan_ranges] array of vlan_start:vlan_stop groups
+# [bridge_mappings]     array of physical_newtork:l2_start:l2end groups
+# [bridge_uplinks]      array of bridge_name:bridge_interface groups
+# [tenant_network_type] vlan, gre, etc. needed by ovs to define the default
 #   The next is an array of arrays, that can be used to add call-out links to the dashboard for other apps.
 #   There is no specific requirement for these apps to be for monitoring, that's just the defacto purpose.
 #   Each app is defined in two parts, the display name, and the URI
@@ -76,11 +80,7 @@
 #   admin_email            => 'my_email@mw.com',
 #   admin_password         => 'my_admin_password',
 #   keystone_db_password   => 'changeme',
-#   keystone_admin_token   => '12345',
-#   glance_db_password     => 'changeme',
-#   glance_user_password   => 'changeme',
-#   nova_db_password       => 'changeme',
-#   nova_user_password     => 'changeme',
+#   keystone_admin_token   => 'changeme',
 #   secret_key             => 'dummy_secret_key',
 #   nova_user_password     => 'changeme',
 #   nova_db_password       => 'changeme',
@@ -88,10 +88,7 @@
 #   glance_db_password     => 'changeme',
 #   cinder_user_password   => 'changeme',
 #   cinder_db_password     => 'changeme',
-#   keystone_db_password   => 'changeme',
-#   admin_password         => 'changeme',
 #   rabbit_password        => 'changeme',
-#   keystone_admin_token   => 'changeme',
 #   quantum_user_password  => 'changeme',
 #   quantum_db_password    => 'changeme',
 #   secret_key             => 'dummy_secret_key',
@@ -193,6 +190,10 @@ class openstack::all (
   $quantum                 = true,
   $bridge_interface        = undef,
   $external_bridge_name    = 'br-ex',
+  $network_vlan_ranges     = undef,
+  $bridge_mappings         = undef,
+  $bridge_uplinks          = undef,
+  $tenant_network_type     = 'gre',
   $enable_ovs_agent        = true,
   $enable_dhcp_agent       = true,
   $enable_l3_agent         = true,
@@ -407,6 +408,19 @@ class openstack::all (
     if ! $bridge_interface {
       fail('bridge_interface must be set when configuring quantum')
     }
+    # compare incoming bridge definitions to determie if we need
+    # to construct them, or if they were passed in
+    if ! $bridge_mappings {
+      $bridge_mappings_real = ["default:${external_bridge_name}"]
+    } else {
+      $bridge_mappings_real = $bridge_mappings
+    }
+
+    if ! $bridge_uplinks {
+      $bridge_uplinks_real = ["${external_bridge_name}:${bridge_interface}"]
+    } else {
+      $bridge_uplinks_real = $bridge_uplinks
+    }
 
     class { 'openstack::quantum':
       # Database
@@ -418,8 +432,10 @@ class openstack::all (
       rabbit_virtual_host   => $rabbit_virtual_host,
       # Quantum OVS
       ovs_local_ip          => $ovs_local_ip_real,
-      bridge_uplinks        => ["${external_bridge_name}:${bridge_interface}"],
-      bridge_mappings       => ["default:${external_bridge_name}"],
+      network_vlan_ranges   => $network_vlan_ranges,
+      bridge_uplinks        => $bridge_uplinks_real,
+      bridge_mappings       => $bridge_mappings_real,
+      tenant_network_type   => $tenant_network_type,
       enable_ovs_agent      => $enable_ovs_agent,
       firewall_driver       => $firewall_driver,
       # Database

--- a/spec/classes/openstack_all_spec.rb
+++ b/spec/classes/openstack_all_spec.rb
@@ -125,6 +125,49 @@ describe 'openstack::all' do
         )
       end
     end
+
+    context 'with quantum_user_password, quantum_db_password, bridge_interface, ovs_local_ip, bride_mappings, bridge_uplinks, and shared_secret set' do
+      before do
+        params.merge!(
+          :quantum_user_password => 'quantum_user_password',
+          :quantum_db_password   => 'quantum_db_password',
+          :bridge_interface      => 'eth0',
+          :ovs_local_ip          => '10.0.1.1',
+          :network_vlan_ranges => '1:1000',
+          :bridge_mappings     => ['intranet:br-intra','extranet:br-extra'],
+          :bridge_uplinks      => ['intranet:eth1','extranet:eth2'],
+          :metadata_shared_secret => 'shared_md_secret'
+        )
+      end
+      it 'contains an openstack::quantum class' do
+        should contain_class('openstack::quantum').with(
+          :db_host             => '127.0.0.1',
+          :rabbit_host         => '127.0.0.1',
+          :rabbit_user         => 'openstack',
+          :rabbit_password     => 'rabbit_pw',
+          :rabbit_virtual_host => '/',
+          :ovs_local_ip        => '10.0.1.1',
+          :network_vlan_ranges => '1:1000',
+          :bridge_uplinks      => ['intranet:eth1','extranet:eth2'],
+          :bridge_mappings     => ['intranet:br-intra','extranet:br-extra'],
+          :enable_ovs_agent    => true,
+          :firewall_driver     => 'quantum.agent.linux.iptables_firewall.OVSHybridIptablesFirewallDriver',
+          :db_name             => 'quantum',
+          :db_user             => 'quantum',
+          :db_password         => 'quantum_db_password',
+          :enable_dhcp_agent   => true,
+          :enable_l3_agent     => true,
+          :enable_metadata_agent => true,
+          :auth_url            => 'http://127.0.0.1:35357/v2.0',
+          :user_password       => 'quantum_user_password',
+          :shared_secret       => 'shared_md_secret',
+          :keystone_host       => '127.0.0.1',
+          :enabled             => true,
+          :enable_server       => true,
+          :verbose             => false
+        )
+      end
+    end
   end
 
   context 'cinder enabled (which is the default)' do


### PR DESCRIPTION
All.pp is missing the parameters needed to enable provider
networks, making certain network configurations difficult
or impossible with an all-in-one deployment

Goes with https://github.com/CiscoSystems/grizzly-manifests/pull/146
Needed for allinone with ovs provider networks
