### PR TITLE
Bug[1218981]: Fix storage node ring sync export conflicts

### DIFF
--- a/manifests/swift/proxy.pp
+++ b/manifests/swift/proxy.pp
@@ -107,11 +107,6 @@ class openstack::swift::proxy (
     local_net_ip => $swift_local_net_ip,
   }
 
-  # exports rsync gets that can be used to sync the ring files
-  @@swift::ringsync { ['account', 'object', 'container']:
-    ring_server => $swift_local_net_ip
-  }
-
   # deploy a script that can be used for testing
   class {'swift::test_file':
     auth_server  => $real_keystone_host,

--- a/manifests/swift/storage-node.pp
+++ b/manifests/swift/storage-node.pp
@@ -1,5 +1,6 @@
 class openstack::swift::storage-node (
   $swift_zone,
+  $ring_server,
   $swift_hash_suffix    = 'swift_secret',
   $swift_local_net_ip   = $::ipaddress_eth0,
   $storage_type         = 'loopback',
@@ -47,7 +48,9 @@ class openstack::swift::storage-node (
     weight             => $storage_weight,
   }
 
-  # collect resources for synchronizing the ring databases
-  Swift::Ringsync<<||>>
+  # rsync rings from the ring server
+  swift::ringsync { ['account','container','object']:
+    ring_server => $ring_server,
+  }
 
 }


### PR DESCRIPTION
This pull request addresses launchpad bug 1218981 upstream bug 1224592. A patch has been submitted to upstream master but will not be back ported to grizzly because it breaks backwards compatibility.
