### PR TITLE
Add account and container quotas in swift pipeline

### DIFF
--- a/manifests/swift/proxy.pp
+++ b/manifests/swift/proxy.pp
@@ -8,7 +8,7 @@ class openstack::swift::proxy (
   $ring_part_power                  = 18,
   $ring_replicas                    = 3,
   $ring_min_part_hours              = 1,
-  $proxy_pipeline                   = ['catch_errors', 'healthcheck', 'cache', 'ratelimit', 'swift3', 's3token', 'authtoken', 'keystone', 'proxy-server'],
+  $proxy_pipeline                   = ['catch_errors', 'healthcheck', 'cache', 'ratelimit', 'swift3', 's3token', 'authtoken', 'keystone', 'account_quotas', 'container_quotas', 'proxy-server'],
   $proxy_workers                    = $::processorcount,
   $proxy_port                       = '8080',
   $proxy_allow_account_management   = true,
@@ -58,7 +58,9 @@ class openstack::swift::proxy (
 
   # configure all of the middlewares
   class { [
+    '::swift::proxy::account_quotas',
     '::swift::proxy::catch_errors',
+    '::swift::proxy::container_quotas',
     '::swift::proxy::healthcheck',
     '::swift::proxy::swift3',
   ]: }


### PR DESCRIPTION
Account quotas and container quotas were added in the swift module but
not in the openstack composition layer. Include there with all the other
swift middleware also.

Change-Id: I7e5a584afeb20ff7d4d382bc021382a5be727afe
Closes-Bug: #1321614
(cherry picked from commit b31b4f515fbba42417a9729642cd013928d74ea0)
